### PR TITLE
New controller argument passing and moved CommandHandler's name into its class.

### DIFF
--- a/src/com/dd/DandD.java
+++ b/src/com/dd/DandD.java
@@ -1,6 +1,7 @@
 package com.dd;
 
 import com.dd.SceneControllerTuple;
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -72,7 +73,7 @@ public class DandD extends Application {
         gameSceneControllerMap.put(name, tuple);
     }
 
-    public static void setActiveGameScene(String name, Object[] args) {
+    public static void setActiveGameScene(String name, ControllerArgumentPackage args) {
         SceneControllerTuple tuple = gameSceneControllerMap.get(name);
         if(tuple == null)
             throw new IllegalArgumentException("GameScene \""

--- a/src/com/dd/command_util/CommandHandler.java
+++ b/src/com/dd/command_util/CommandHandler.java
@@ -9,6 +9,11 @@ import com.dd.levels.MapPosition;
 import com.dd.levels.Room;
 
 public abstract class CommandHandler {
+    protected String name;
+
+    public CommandHandler(String name){
+        this.name = name;
+    }
 
 	//public abstract void handleCommand(String[] args, CommandOutputLog outputLog) throws CommandHandlerException, FileNotFoundException;
 	public abstract void handleCommand(String[] args, CommandOutputLog outputLog) throws FileNotFoundException;
@@ -20,5 +25,9 @@ public abstract class CommandHandler {
         }
         argsStr += args[args.length - 1];
         return argsStr;
+    }
+
+    public String getName(){
+	    return name;
     }
 }

--- a/src/com/dd/command_util/CommandParser.java
+++ b/src/com/dd/command_util/CommandParser.java
@@ -42,11 +42,12 @@ public class CommandParser {
     	handler.handleCommand(args, outputLog);
 	}
 
-    public void registerCommand(String commandName, CommandHandler commandHandler) {
+    public void registerCommand(CommandHandler commandHandler) {
+        String commandName = commandHandler.getName();
         if(commandMap.containsKey(commandName))
             throw new IllegalArgumentException("The command \""
                                                 + commandName
-                                                + "\" has already been registerd with this CommandParser. Registration failed.");
+                                                + "\" has already been registered with this CommandParser. Registration failed.");
         if(commandHandler == null)
             throw new IllegalArgumentException("The command handler passed for \""
                                                     + commandName
@@ -55,11 +56,12 @@ public class CommandParser {
         commandMap.put(commandName, commandHandler);
     }
 
-    public void unregisterCommand(String commandName, CommandHandler commandHandler) {
+    public void unregisterCommand(CommandHandler commandHandler) {
+        String commandName = commandHandler.getName();
         if(!commandMap.containsKey(commandName))
             throw new IllegalArgumentException("The command \""
                                                 + commandName
-                                                + "\" has not been registered with this CommandParser. Unregistration failed.");
+                                                + "\" has not been registered with this CommandParser. Un-registration failed.");
     }
 
     public void setOutputLog(CommandOutputLog outputLog){

--- a/src/com/dd/command_util/command/AttackCommand.java
+++ b/src/com/dd/command_util/command/AttackCommand.java
@@ -10,7 +10,8 @@ public class AttackCommand extends CommandHandler {
     private Player player;
     private DungeonMap map;
 
-    public AttackCommand(GameState gameState){
+    public AttackCommand(String name, GameState gameState){
+        super(name);
         player = gameState.getActivePlayer();
         map = gameState.getMap();
     }

--- a/src/com/dd/command_util/command/DropCommand.java
+++ b/src/com/dd/command_util/command/DropCommand.java
@@ -15,7 +15,8 @@ public class DropCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public DropCommand(GameState gameState) {
+    public DropCommand(String name, GameState gameState) {
+    	super(name);
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/EquipCommand.java
+++ b/src/com/dd/command_util/command/EquipCommand.java
@@ -15,8 +15,9 @@ public class EquipCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap dungeonMap;
 
-    public EquipCommand(GameState gameState) {
-		this.player = gameState.getActivePlayer();
+    public EquipCommand(String name, GameState gameState) {
+		super(name);
+    	this.player = gameState.getActivePlayer();
 		this.dungeonMap = gameState.getMap();
 	}
 

--- a/src/com/dd/command_util/command/ExamineCommand.java
+++ b/src/com/dd/command_util/command/ExamineCommand.java
@@ -13,7 +13,8 @@ public class ExamineCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public ExamineCommand(GameState gameState) {
+    public ExamineCommand(String name, GameState gameState) {
+    	super(name);
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/HelpCommand.java
+++ b/src/com/dd/command_util/command/HelpCommand.java
@@ -4,7 +4,9 @@ import com.dd.command_util.CommandHandler;
 import com.dd.command_util.CommandOutputLog;
 
 public class HelpCommand extends CommandHandler {
-    public HelpCommand() {}
+    public HelpCommand(String name) {
+    	super(name);
+	}
 	
 	@Override
 	public void handleCommand(String[] args, CommandOutputLog outputLog){

--- a/src/com/dd/command_util/command/MoveCommand.java
+++ b/src/com/dd/command_util/command/MoveCommand.java
@@ -13,7 +13,8 @@ public class MoveCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public MoveCommand(GameState gameState) {
+    public MoveCommand(String name, GameState gameState) {
+    	super(name);
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/PickupCommand.java
+++ b/src/com/dd/command_util/command/PickupCommand.java
@@ -10,7 +10,8 @@ public class PickupCommand extends CommandHandler {
     private Player player;
     private DungeonMap map;
 
-    public PickupCommand(GameState gameState) {
+    public PickupCommand(String name, GameState gameState) {
+        super(name);
         player = gameState.getActivePlayer();
         map = gameState.getMap();
     }

--- a/src/com/dd/command_util/command/UseCommand.java
+++ b/src/com/dd/command_util/command/UseCommand.java
@@ -4,7 +4,9 @@ import com.dd.command_util.CommandHandler;
 import com.dd.command_util.CommandOutputLog;
 
 public class UseCommand extends CommandHandler {
-    public UseCommand() {}
+    public UseCommand(String name) {
+        super(name);
+    }
 
     @Override
     public void handleCommand(String[] args, CommandOutputLog outputLog){

--- a/src/com/dd/controller_util/ControllerArgumentPackage.java
+++ b/src/com/dd/controller_util/ControllerArgumentPackage.java
@@ -1,0 +1,25 @@
+package com.dd.controller_util;
+
+import java.lang.ClassCastException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerArgumentPackage {
+    private Map<String, Object> argMap = new HashMap<String, Object>();
+
+    public void setArgument(String argName, Object arg){
+        argMap.put(argName, arg);
+    }
+
+    public <T> T getArgument(String argName) {
+        try {
+            T argOut = (T)argMap.get(argName);
+            if(argOut == null)
+                throw new IllegalArgumentException("");
+            return argOut;
+        }
+        catch(ClassCastException e) {
+            throw new IllegalArgumentException("");
+        }
+    }
+}

--- a/src/com/dd/controller_util/GameSceneController.java
+++ b/src/com/dd/controller_util/GameSceneController.java
@@ -1,6 +1,8 @@
 package com.dd.controller_util;
 
+import com.dd.controller_util.ControllerArgumentPackage;
+
 public abstract class GameSceneController{
-    public abstract void setup(Object[] args);
+    public abstract void setup(ControllerArgumentPackage args);
     public abstract void teardown();
 }

--- a/src/com/dd/controller_util/controller/AddServerController.java
+++ b/src/com/dd/controller_util/controller/AddServerController.java
@@ -1,10 +1,11 @@
 package com.dd.controller_util.controller;
 
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 
 public class AddServerController extends GameSceneController{
     @Override
-    public void setup(Object[] args){
+    public void setup(ControllerArgumentPackage args){
 
     }
 

--- a/src/com/dd/controller_util/controller/CharacterCreationController.java
+++ b/src/com/dd/controller_util/controller/CharacterCreationController.java
@@ -1,10 +1,11 @@
 package com.dd.controller_util.controller;
 
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 
 public class CharacterCreationController extends GameSceneController{
     @Override
-    public void setup(Object[] args){
+    public void setup(ControllerArgumentPackage args){
 
     }
 

--- a/src/com/dd/controller_util/controller/JoinGameController.java
+++ b/src/com/dd/controller_util/controller/JoinGameController.java
@@ -1,10 +1,11 @@
 package com.dd.controller_util.controller;
 
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 
 public class JoinGameController extends GameSceneController{
     @Override
-    public void setup(Object[] args){
+    public void setup(ControllerArgumentPackage args){
 
     }
 

--- a/src/com/dd/controller_util/controller/LoadGameController.java
+++ b/src/com/dd/controller_util/controller/LoadGameController.java
@@ -3,6 +3,7 @@ package com.dd.controller_util.controller;
 
 import com.dd.DandD;
 import com.dd.GameState;
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 import com.google.gson.Gson;
 import java.io.File;
@@ -68,7 +69,7 @@ public class LoadGameController extends GameSceneController{
 	}
 
 	@Override
-	public void setup(Object[] args){
+	public void setup(ControllerArgumentPackage args){
 
 	}
 

--- a/src/com/dd/controller_util/controller/MainMenuController.java
+++ b/src/com/dd/controller_util/controller/MainMenuController.java
@@ -3,6 +3,7 @@ package com.dd.controller_util.controller;
 import java.io.IOException;
 
 import com.dd.DandD;
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -49,7 +50,7 @@ public class MainMenuController extends GameSceneController{
 	}
 
 	@Override
-	public void setup(Object[] args){
+	public void setup(ControllerArgumentPackage args){
 
 	}
 

--- a/src/com/dd/controller_util/controller/NewGameController.java
+++ b/src/com/dd/controller_util/controller/NewGameController.java
@@ -2,6 +2,7 @@ package com.dd.controller_util.controller;
 
 import com.dd.DandD;
 import com.dd.GameState;
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 import com.dd.entities.Player;
 import com.dd.entities.monsters.*;
@@ -45,7 +46,10 @@ public class NewGameController extends GameSceneController{
 		DungeonMap map = generateDungeonMap(5, 5);
 		GameState game = new GameState(saveName.getText(), new Player(characterName.getText()), map);
 
-		DandD.setActiveGameScene("RunningGameScene", new Object[]{game});
+		ControllerArgumentPackage args = new ControllerArgumentPackage();
+		args.setArgument("GameState", game);
+
+		DandD.setActiveGameScene("RunningGameScene", args);
 	}
 	
 	/**
@@ -150,7 +154,7 @@ public class NewGameController extends GameSceneController{
 	}
 
 	@Override
-	public void setup(Object[] args){
+	public void setup(ControllerArgumentPackage args){
 
 	}
 

--- a/src/com/dd/controller_util/controller/RunningGameController.java
+++ b/src/com/dd/controller_util/controller/RunningGameController.java
@@ -11,6 +11,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import com.dd.controller_util.ControllerArgumentPackage;
 import com.dd.controller_util.GameSceneController;
 import com.google.gson.Gson;
 import javafx.application.Platform;
@@ -101,18 +102,18 @@ public class RunningGameController extends GameSceneController{
 	}
 
 	@Override
-	public void setup(Object[] args){
-		GameState gameState = (GameState)args[0];
+	public void setup(ControllerArgumentPackage args){
+		GameState gameState = args.getArgument("GameState");
 		this.gameState = gameState;
 		commandParser = new CommandParser(new CommandOutputLog(output));
-		commandParser.registerCommand("move", new MoveCommand(gameState));
-		commandParser.registerCommand("examine", new ExamineCommand(gameState));
-		commandParser.registerCommand("drop", new DropCommand(gameState));
-		commandParser.registerCommand("attack", new AttackCommand(gameState));
-		commandParser.registerCommand("equip", new EquipCommand(gameState));
-		commandParser.registerCommand("help", new HelpCommand());
-		commandParser.registerCommand("pickup", new PickupCommand(gameState));
-		commandParser.registerCommand("use", new UseCommand());
+		commandParser.registerCommand(new MoveCommand("move", gameState));
+		commandParser.registerCommand(new ExamineCommand("examine", gameState));
+		commandParser.registerCommand(new DropCommand("drop", gameState));
+		commandParser.registerCommand(new AttackCommand("attack", gameState));
+		commandParser.registerCommand(new EquipCommand("equip", gameState));
+		commandParser.registerCommand(new HelpCommand("help"));
+		commandParser.registerCommand(new PickupCommand("pickup", gameState));
+		commandParser.registerCommand(new UseCommand("use"));
 	}
 
 	@Override


### PR DESCRIPTION
This pull request has 2 features:

**New Controller Argument Passing Method**
A new method was devised for passing arguments when switching between Scenes/Controllers. This makes use of an object called ControllerArgumentPackage which is a wrapper class for a HashMap. The purpose of this is to make use of a generic "getArgument" method that will make the receiving Controller's code cleaner because it will not have to worry about typecasting or order of the arguments that it receives. That being said if it requests an argument not present(or of a different type than it is trying to assign to) in the ControllerArgumentPackage then the application will crash due to an IllegalArgumentException. This is intentional because it would not be possible to recover from this type of situation and would imply that the code itself was flawed, not the way it was used.

**NOTE:**
I am not saying this is the best solution for argument passing between controllers, it is simply one I came up with. As far as I am aware the only way to pass arguments between Controllers with our current system without casting would require us to get a copy of the controller and call set methods. Though at that point it might be best to use the more common JavaFX methodology for loading each Controller when we switch Scenes and calling the appropriate setters. The only reason I have not switched us over to that methodology is that members of the group have seemed fond of our current Scene switching methodology. If the group wants to switch to the JavaFX approach over this one I am perfectly fine with that.

**CommandHandler name is not internal to the class**
Previously, the "name" tied to a CommandHandler(the name the CommandParser used to identify it) was supplied to the CommandParser object when the CommandHandler was registered to it. This update puts that value inside of the CommandhHandler class. This CommandParser class still references the CommandHandler class in the same way(through its "name") but now it gets the name from the created CommandHandler itself rather than from an argument in the "registerCommand" method. There are two reasons this was chosen:

1. It gives slightly more flexibility in error reporting inside the CommandHandlers since they now implicitly know what they are called.
2. It will(assuming my current design plans continue to be valid) be very useful in the network code I plan to write.