### PR TITLE
Change to CommandHandler names and simple typo fix.

### DIFF
--- a/src/com/dd/GameType.java
+++ b/src/com/dd/GameType.java
@@ -1,0 +1,5 @@
+package com.dd;
+
+public enum GameType{
+    LOCAL, NET_SERVER, NET_CLIENT
+}

--- a/src/com/dd/command_util/CommandHandler.java
+++ b/src/com/dd/command_util/CommandHandler.java
@@ -9,7 +9,7 @@ import com.dd.levels.MapPosition;
 import com.dd.levels.Room;
 
 public abstract class CommandHandler {
-	public abstract void handleCommand(String[] args, CommandOutputLog outputLog) throws FileNotFoundException;
+	public abstract void handleCommand(String commandName, String[] args, CommandOutputLog outputLog) throws FileNotFoundException;
 
 	protected String getArgsString(String args[]){
         String argsStr = "";

--- a/src/com/dd/command_util/CommandHandler.java
+++ b/src/com/dd/command_util/CommandHandler.java
@@ -9,13 +9,6 @@ import com.dd.levels.MapPosition;
 import com.dd.levels.Room;
 
 public abstract class CommandHandler {
-    protected String name;
-
-    public CommandHandler(String name){
-        this.name = name;
-    }
-
-	//public abstract void handleCommand(String[] args, CommandOutputLog outputLog) throws CommandHandlerException, FileNotFoundException;
 	public abstract void handleCommand(String[] args, CommandOutputLog outputLog) throws FileNotFoundException;
 
 	protected String getArgsString(String args[]){
@@ -25,9 +18,5 @@ public abstract class CommandHandler {
         }
         argsStr += args[args.length - 1];
         return argsStr;
-    }
-
-    public String getName(){
-	    return name;
     }
 }

--- a/src/com/dd/command_util/CommandParser.java
+++ b/src/com/dd/command_util/CommandParser.java
@@ -39,7 +39,7 @@ public class CommandParser {
                                                 + command
                                                 + "\" is not registered with the CommandParser.");
         }
-    	handler.handleCommand(args, outputLog);
+    	handler.handleCommand(command, args, outputLog);
 	}
 
     public void registerCommand(String commandName, CommandHandler commandHandler) {

--- a/src/com/dd/command_util/CommandParser.java
+++ b/src/com/dd/command_util/CommandParser.java
@@ -42,8 +42,7 @@ public class CommandParser {
     	handler.handleCommand(args, outputLog);
 	}
 
-    public void registerCommand(CommandHandler commandHandler) {
-        String commandName = commandHandler.getName();
+    public void registerCommand(String commandName, CommandHandler commandHandler) {
         if(commandMap.containsKey(commandName))
             throw new IllegalArgumentException("The command \""
                                                 + commandName
@@ -56,8 +55,7 @@ public class CommandParser {
         commandMap.put(commandName, commandHandler);
     }
 
-    public void unregisterCommand(CommandHandler commandHandler) {
-        String commandName = commandHandler.getName();
+    public void unregisterCommand(String commandName, CommandHandler commandHandler) {
         if(!commandMap.containsKey(commandName))
             throw new IllegalArgumentException("The command \""
                                                 + commandName

--- a/src/com/dd/command_util/command/AttackCommand.java
+++ b/src/com/dd/command_util/command/AttackCommand.java
@@ -16,7 +16,7 @@ public class AttackCommand extends CommandHandler {
     }
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
 
     }
 }

--- a/src/com/dd/command_util/command/AttackCommand.java
+++ b/src/com/dd/command_util/command/AttackCommand.java
@@ -10,8 +10,7 @@ public class AttackCommand extends CommandHandler {
     private Player player;
     private DungeonMap map;
 
-    public AttackCommand(String name, GameState gameState){
-        super(name);
+    public AttackCommand(GameState gameState){
         player = gameState.getActivePlayer();
         map = gameState.getMap();
     }

--- a/src/com/dd/command_util/command/DropCommand.java
+++ b/src/com/dd/command_util/command/DropCommand.java
@@ -15,8 +15,7 @@ public class DropCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public DropCommand(String name, GameState gameState) {
-    	super(name);
+    public DropCommand(GameState gameState) {
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/DropCommand.java
+++ b/src/com/dd/command_util/command/DropCommand.java
@@ -21,7 +21,7 @@ public class DropCommand extends CommandHandler {
 	}
 
 	@Override
-	public void handleCommand(String[] args, CommandOutputLog outputLog){
+	public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
 		Room room = map.getRoom(player.getPostion());
 		if(args.length > 1) {
 			outputLog.printToLog("Invalid arguments \""

--- a/src/com/dd/command_util/command/EquipCommand.java
+++ b/src/com/dd/command_util/command/EquipCommand.java
@@ -15,8 +15,7 @@ public class EquipCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap dungeonMap;
 
-    public EquipCommand(String name, GameState gameState) {
-		super(name);
+    public EquipCommand(GameState gameState) {
     	this.player = gameState.getActivePlayer();
 		this.dungeonMap = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/EquipCommand.java
+++ b/src/com/dd/command_util/command/EquipCommand.java
@@ -21,7 +21,7 @@ public class EquipCommand extends CommandHandler {
 	}
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
     	if(args.length != 1){
 			outputLog.printToLog("Invalid arguments \""
 					+ getArgsString(args)

--- a/src/com/dd/command_util/command/ExamineCommand.java
+++ b/src/com/dd/command_util/command/ExamineCommand.java
@@ -13,8 +13,7 @@ public class ExamineCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public ExamineCommand(String name, GameState gameState) {
-    	super(name);
+    public ExamineCommand(GameState gameState) {
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/ExamineCommand.java
+++ b/src/com/dd/command_util/command/ExamineCommand.java
@@ -19,7 +19,7 @@ public class ExamineCommand extends CommandHandler {
 	}
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
     	if(args.length != 1){
 			outputLog.printToLog("Invalid arguments \""
 					+ getArgsString(args)

--- a/src/com/dd/command_util/command/HelpCommand.java
+++ b/src/com/dd/command_util/command/HelpCommand.java
@@ -4,9 +4,7 @@ import com.dd.command_util.CommandHandler;
 import com.dd.command_util.CommandOutputLog;
 
 public class HelpCommand extends CommandHandler {
-    public HelpCommand(String name) {
-    	super(name);
-	}
+    public HelpCommand() {}
 	
 	@Override
 	public void handleCommand(String[] args, CommandOutputLog outputLog){

--- a/src/com/dd/command_util/command/HelpCommand.java
+++ b/src/com/dd/command_util/command/HelpCommand.java
@@ -7,7 +7,7 @@ public class HelpCommand extends CommandHandler {
     public HelpCommand() {}
 	
 	@Override
-	public void handleCommand(String[] args, CommandOutputLog outputLog){
+	public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
     	if(args.length != 0){
 			outputLog.printToLog("Invalid arguments \""
 					+ getArgsString(args)

--- a/src/com/dd/command_util/command/MoveCommand.java
+++ b/src/com/dd/command_util/command/MoveCommand.java
@@ -13,8 +13,7 @@ public class MoveCommand extends CommandHandler {
 	private Player player;
 	private DungeonMap map;
 
-    public MoveCommand(String name, GameState gameState) {
-    	super(name);
+    public MoveCommand(GameState gameState) {
     	player = gameState.getActivePlayer();
     	map = gameState.getMap();
 	}

--- a/src/com/dd/command_util/command/MoveCommand.java
+++ b/src/com/dd/command_util/command/MoveCommand.java
@@ -19,7 +19,7 @@ public class MoveCommand extends CommandHandler {
 	}
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog) {
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog) {
 		if(args.length > 1) {
 			outputLog.printToLog("Invalid arguments \""
 					+ getArgsString(args)

--- a/src/com/dd/command_util/command/NetworkHandledCommand.java
+++ b/src/com/dd/command_util/command/NetworkHandledCommand.java
@@ -15,7 +15,7 @@ public class NetworkHandledCommand extends CommandHandler{
     }
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
 
     }
 }

--- a/src/com/dd/command_util/command/NetworkHandledCommand.java
+++ b/src/com/dd/command_util/command/NetworkHandledCommand.java
@@ -1,0 +1,21 @@
+package com.dd.command_util.command;
+
+import com.dd.command_util.CommandHandler;
+import com.dd.command_util.CommandOutputLog;
+import com.dd.network.NetworkCommChannel;
+import com.dd.network.NetworkCommInerpreter;
+
+public class NetworkHandledCommand extends CommandHandler{
+    private NetworkCommChannel channel;
+    private NetworkCommInerpreter interpreter;
+
+    public NetworkHandledCommand(NetworkCommChannel channel, NetworkCommInerpreter interpreter){
+        this.channel = channel;
+        this.interpreter = interpreter;
+    }
+
+    @Override
+    public void handleCommand(String[] args, CommandOutputLog outputLog){
+
+    }
+}

--- a/src/com/dd/command_util/command/NetworkHandledCommand.java
+++ b/src/com/dd/command_util/command/NetworkHandledCommand.java
@@ -1,15 +1,18 @@
 package com.dd.command_util.command;
 
+import com.dd.GameState;
 import com.dd.command_util.CommandHandler;
 import com.dd.command_util.CommandOutputLog;
 import com.dd.network.NetworkCommChannel;
-import com.dd.network.NetworkCommInerpreter;
+import com.dd.network.NetworkCommInterpreter;
 
 public class NetworkHandledCommand extends CommandHandler{
+    private GameState gameState;
     private NetworkCommChannel channel;
-    private NetworkCommInerpreter interpreter;
+    private NetworkCommInterpreter interpreter;
 
-    public NetworkHandledCommand(NetworkCommChannel channel, NetworkCommInerpreter interpreter){
+    public NetworkHandledCommand(NetworkCommChannel channel, NetworkCommInterpreter interpreter, GameState gameState){
+        this.gameState = gameState;
         this.channel = channel;
         this.interpreter = interpreter;
     }

--- a/src/com/dd/command_util/command/PickupCommand.java
+++ b/src/com/dd/command_util/command/PickupCommand.java
@@ -10,8 +10,7 @@ public class PickupCommand extends CommandHandler {
     private Player player;
     private DungeonMap map;
 
-    public PickupCommand(String name, GameState gameState) {
-        super(name);
+    public PickupCommand(GameState gameState) {
         player = gameState.getActivePlayer();
         map = gameState.getMap();
     }

--- a/src/com/dd/command_util/command/PickupCommand.java
+++ b/src/com/dd/command_util/command/PickupCommand.java
@@ -16,7 +16,7 @@ public class PickupCommand extends CommandHandler {
     }
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
 
     }
 }

--- a/src/com/dd/command_util/command/UseCommand.java
+++ b/src/com/dd/command_util/command/UseCommand.java
@@ -7,7 +7,7 @@ public class UseCommand extends CommandHandler {
     public UseCommand() {}
 
     @Override
-    public void handleCommand(String[] args, CommandOutputLog outputLog){
+    public void handleCommand(String commandName, String[] args, CommandOutputLog outputLog){
 
     }
 }

--- a/src/com/dd/command_util/command/UseCommand.java
+++ b/src/com/dd/command_util/command/UseCommand.java
@@ -4,9 +4,7 @@ import com.dd.command_util.CommandHandler;
 import com.dd.command_util.CommandOutputLog;
 
 public class UseCommand extends CommandHandler {
-    public UseCommand(String name) {
-        super(name);
-    }
+    public UseCommand() {}
 
     @Override
     public void handleCommand(String[] args, CommandOutputLog outputLog){

--- a/src/com/dd/controller_util/controller/RunningGameController.java
+++ b/src/com/dd/controller_util/controller/RunningGameController.java
@@ -1,19 +1,18 @@
 package com.dd.controller_util.controller;
 
+import com.google.gson.Gson;
 import com.dd.DandD;
 import com.dd.GameState;
+import com.dd.GameType;
 import com.dd.command_util.CommandOutputLog;
 import com.dd.command_util.CommandParser;
 import com.dd.command_util.command.*;
-
+import com.dd.controller_util.ControllerArgumentPackage;
+import com.dd.controller_util.GameSceneController;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-
-import com.dd.controller_util.ControllerArgumentPackage;
-import com.dd.controller_util.GameSceneController;
-import com.google.gson.Gson;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -106,14 +105,14 @@ public class RunningGameController extends GameSceneController{
 		GameState gameState = args.getArgument("GameState");
 		this.gameState = gameState;
 		commandParser = new CommandParser(new CommandOutputLog(output));
-		commandParser.registerCommand(new MoveCommand("move", gameState));
-		commandParser.registerCommand(new ExamineCommand("examine", gameState));
-		commandParser.registerCommand(new DropCommand("drop", gameState));
-		commandParser.registerCommand(new AttackCommand("attack", gameState));
-		commandParser.registerCommand(new EquipCommand("equip", gameState));
-		commandParser.registerCommand(new HelpCommand("help"));
-		commandParser.registerCommand(new PickupCommand("pickup", gameState));
-		commandParser.registerCommand(new UseCommand("use"));
+		commandParser.registerCommand("move", new MoveCommand(gameState));
+		commandParser.registerCommand("examine", new ExamineCommand(gameState));
+		commandParser.registerCommand("drop", new DropCommand(gameState));
+		commandParser.registerCommand("attack", new AttackCommand(gameState));
+		commandParser.registerCommand("equip", new EquipCommand(gameState));
+		commandParser.registerCommand("help", new HelpCommand());
+		commandParser.registerCommand("pickup", new PickupCommand(gameState));
+		commandParser.registerCommand("use", new UseCommand());
 	}
 
 	@Override

--- a/src/com/dd/network/NetworkCommChannel.java
+++ b/src/com/dd/network/NetworkCommChannel.java
@@ -1,0 +1,4 @@
+package com.dd.network;
+
+public class NetworkCommChannel {
+}

--- a/src/com/dd/network/NetworkCommInerpreter.java
+++ b/src/com/dd/network/NetworkCommInerpreter.java
@@ -1,0 +1,4 @@
+package com.dd.network;
+
+public class NetworkCommInerpreter {
+}

--- a/src/com/dd/network/NetworkCommInerpreter.java
+++ b/src/com/dd/network/NetworkCommInerpreter.java
@@ -1,4 +1,0 @@
-package com.dd.network;
-
-public class NetworkCommInerpreter {
-}

--- a/src/com/dd/network/NetworkCommInterpreter.java
+++ b/src/com/dd/network/NetworkCommInterpreter.java
@@ -1,0 +1,4 @@
+package com.dd.network;
+
+public class NetworkCommInterpreter {
+}


### PR DESCRIPTION
This pull request corrects the previous one by the mixing of the 2 design strategies used for "naming" CommandHandlers. The reason this is necessary is purely a nitpicky efficiency issue, but it allows our networked and non-networked games to function very similarly, at least as far as most of the general code structure is concerned, while not being wasteful. It also still provides the same error reporting capabilities as before. This pull request also lays the groundwork for out networked game code. This should not affect any other dev's code.