### PR TITLE
Remove some unneeded casting

### DIFF
--- a/src/com/dd/GameState.java
+++ b/src/com/dd/GameState.java
@@ -17,15 +17,7 @@ public class GameState implements Serializable {
 	
 	public GameState(String name, Player activePlayer, DungeonMap map, int maxNumPlayers) {
 	    this.name = name;
-	    if(activePlayer instanceof Fighter) {
-	    	this.activePlayer = (Fighter) activePlayer;
-	    }
-	    else if(activePlayer instanceof Wizard) {
-	    	this.activePlayer = (Wizard) activePlayer;
-	    }
-	    else {
-	    	this.activePlayer = activePlayer;
-	    }
+	    this.activePlayer = activePlayer;
         this.maxNumPlayers = maxNumPlayers;
         allActivePlayers = new ArrayList<Player>();
         this.map = map;
@@ -33,15 +25,7 @@ public class GameState implements Serializable {
 
 	public GameState(String name, Player activePlayer, DungeonMap map) {
         this.name = name;
-        if(activePlayer instanceof Fighter) {
-	    	this.activePlayer = (Fighter) activePlayer;
-	    }
-	    else if(activePlayer instanceof Wizard) {
-	    	this.activePlayer = (Wizard) activePlayer;
-	    }
-	    else {
-	    	this.activePlayer = activePlayer;
-	    }
+        this.activePlayer = activePlayer;
         this.maxNumPlayers = 1;
         allActivePlayers = new ArrayList<Player>();
         this.map = map;

--- a/src/com/dd/GameState.java
+++ b/src/com/dd/GameState.java
@@ -24,18 +24,7 @@ public class GameState implements Serializable {
 	}
 
 	public GameState(String name, Player activePlayer, DungeonMap map) {
-        this.name = name;
-        this.activePlayer = activePlayer;
-        this.maxNumPlayers = 1;
-        allActivePlayers = new ArrayList<Player>();
-        this.map = map;
-    }
-	
-	public GameState(String name, DungeonMap map) {
-        this.name = name;
-        this.maxNumPlayers = 1;
-        allActivePlayers = new ArrayList<Player>();
-        this.map = map;
+        this(name, activePlayer, map, 1);
     }
 
     public Player getActivePlayer() {

--- a/src/com/dd/GameState.java
+++ b/src/com/dd/GameState.java
@@ -28,21 +28,11 @@ public class GameState implements Serializable {
     }
 
     public Player getActivePlayer() {
-    	if(activePlayer instanceof Fighter) {
-    		return (Fighter) activePlayer;
-    	}
-    	else if(activePlayer instanceof Wizard) {
-    		return (Wizard) activePlayer;
-    	}
     	return activePlayer;
     }
     
-    public void setActivePlayer(Fighter fighter) {
-    	activePlayer = fighter;
-    }
-    
-    public void setActivePlayer(Wizard wizard) {
-    	activePlayer = wizard;
+    public void setActivePlayer(Player player) {
+        activePlayer = player;
     }
 
     public List<Player> getPlayerList() {

--- a/src/com/dd/command_util/CommandParser.java
+++ b/src/com/dd/command_util/CommandParser.java
@@ -21,12 +21,7 @@ public class CommandParser {
     
     public CommandParser(CommandOutputLog outputLog, GameState game) {
         this.outputLog = outputLog;
-        if(game.getActivePlayer() instanceof Fighter) {
-        	player = (Fighter) game.getActivePlayer();
-        }
-        else if(game.getActivePlayer() instanceof Wizard) {
-        	player = (Wizard) game.getActivePlayer();
-        }
+        this.player = game.getActivePlayer();
     }
     
     public void parse(String userInput) throws InvalidCommandException{

--- a/src/com/dd/command_util/command/PickupCommand.java
+++ b/src/com/dd/command_util/command/PickupCommand.java
@@ -46,38 +46,7 @@ public class PickupCommand extends CommandHandler {
 					outputLog.printToLog(UIE.getMessage());
 				}
 	    		try {
-	    			if(item instanceof Artifact) {
-						item = (Artifact) item;
-						player.equip((Artifact) item);
-					}
-					else if(item instanceof Magical) {
-						item = (Magical) item;
-						player.equip((Magical) item);
-					}
-					else if(item instanceof OneHandedWeapon) {
-						item = (OneHandedWeapon) item;
-						player.equip((OneHandedWeapon) item);
-					}
-					else if(item instanceof Potion) {
-						item = (Potion) item;
-						player.equip((Potion) item);
-					}
-					else if(item instanceof Shield) {
-						item = (Shield) item;
-						player.equip((Shield) item);
-					}
-					else if(item instanceof Suit) {
-						item = (Suit) item;
-						player.equip((Suit) item);
-					}
-					else if(item instanceof TwoHandedWeapon) {
-						item = (TwoHandedWeapon) item;
-						player.equip((TwoHandedWeapon) item);
-					}
-					else {
-						outputLog.printToLog(item.getName() + " could not be equipped "
-								+ "because it has not item type. ");
-					}
+	    			player.equip(item);
 	    			if(player.isEquipSuccess()) {
 	    				equippedItemNames.add(itemName);
 	    			}
@@ -109,38 +78,7 @@ public class PickupCommand extends CommandHandler {
 				throw new InvalidArgumentException("The item \"" + args[0] + "\" is not in this room. ");
 			}
 			try {
-				if(item instanceof Artifact) {
-					item = (Artifact) item;
-					player.equip((Artifact) item);
-				}
-				else if(item instanceof Magical) {
-					item = (Magical) item;
-					player.equip((Magical) item);
-				}
-				else if(item instanceof OneHandedWeapon) {
-					item = (OneHandedWeapon) item;
-					player.equip((OneHandedWeapon) item);
-				}
-				else if(item instanceof Potion) {
-					item = (Potion) item;
-					player.equip((Potion) item);
-				}
-				else if(item instanceof Shield) {
-					item = (Shield) item;
-					player.equip((Shield) item);
-				}
-				else if(item instanceof Suit) {
-					item = (Suit) item;
-					player.equip((Suit) item);
-				}
-				else if(item instanceof TwoHandedWeapon) {
-					item = (TwoHandedWeapon) item;
-					player.equip((TwoHandedWeapon) item);
-				}
-				else {
-					outputLog.printToLog(item.getName() + " could not be equipped "
-							+ "because it has not item type. ");
-				}
+				player.equip(item);
     		}
 			catch(EquipmentException | InventoryException E) {
     			outputLog.printToLog(E.getMessage());

--- a/src/com/dd/controller_util/controller/RunningGameController.java
+++ b/src/com/dd/controller_util/controller/RunningGameController.java
@@ -120,11 +120,11 @@ public class RunningGameController extends GameSceneController{
 				if(x == playerPos.getX() && y == playerPos.getY()) {
 					output.append("[X]");
 				}
-				else if(map.isRoom(new MapPosition(x, y))) {
-					output.append("[ ]");
-				}
 				else if(x == map.getEndPosition().getX() && y == map.getEndPosition().getY()) {
 					output.append("[!]");
+				}
+				else if(map.isRoom(new MapPosition(x, y))) {
+					output.append("[ ]");
 				}
 				else{
 					output.append("   ");

--- a/src/com/dd/entities/Monster.java
+++ b/src/com/dd/entities/Monster.java
@@ -1,6 +1,6 @@
 package com.dd.entities;
 
-public class Monster extends Entity {
+public abstract class Monster extends Entity {
 
 	public Monster(String name, int health, int attack, int defense) {
 		super(name, health, health, attack, defense);

--- a/src/com/dd/entities/Player.java
+++ b/src/com/dd/entities/Player.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class Player extends Entity {
+public abstract class Player extends Entity {
 
 	private MapPosition mapPosition;
 	protected Item suit;

--- a/src/com/dd/entities/monsters/Dragon.java
+++ b/src/com/dd/entities/monsters/Dragon.java
@@ -72,7 +72,7 @@ public class Dragon extends Monster {
     public String confrontText() {
         return "As you enter the large room, the first thing that catches your eye is jewels, mostly " + dragColor
                 + ". As you walk around the abnormally large room, you hear a faint hum behind you. As you turn around, "
-                + "a giant " + dragColor + " scaled dragon faces you, nostrils flared. \"Fool! You think you could steal"
+                + "a giant " + dragColor + " scaled dragon faces you, nostrils flared. \"Fool! You think you could steal "
                 + "from " + titleToString() + " dragon? For this, you shall die!\". ";
     }
 

--- a/src/com/dd/items/Item.java
+++ b/src/com/dd/items/Item.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 
 import com.dd.Stats;
 
-public class Item implements Serializable {
+public abstract class Item implements Serializable {
 	
 	protected String name;
 	protected Stats StatModifyer;


### PR DESCRIPTION
This pull request removes some unnecessary casting. There is more to be removed in Player, Fighter, and Wizard's equip methods.

These things also changed:
- Monster, Player, and Item are abstract classes.
- The map now displays the end room.
- Small text fix for Dragon.